### PR TITLE
Update model variable value to 'gpt-4o'.

### DIFF
--- a/src/mention.ts
+++ b/src/mention.ts
@@ -18,7 +18,7 @@ export const appMention: any = async ({ event, client, say }) => {
     }
 
     const nonNullable = <T>(value: T): value is NonNullable<T> => value != null
-    let model = 'gpt-4-turbo'
+    let model = 'gpt-4o'
     let max_tokens = null
     const threadMessages = await Promise.all(
       replies.messages.map(async (message) => {
@@ -38,7 +38,6 @@ export const appMention: any = async ({ event, client, say }) => {
               }
 
               if (encodedImage) {
-                model = 'gpt-4-vision-preview'
                 max_tokens = 4096
                 contents.push(
                   {


### PR DESCRIPTION
OpenAI has released GPT-4o, which is faster and more cost-effective than GPT-4-Turbo (ref: https://platform.openai.com/docs/models/gpt-4o). I have updated the model to GPT-4o accordingly.

I have also removed GPT-Vision-Preview, as it will be deprecated in December 2024 and GPT-4o is also capable of image processing.