### PR TITLE
Specify GPT model as an environment variable

### DIFF
--- a/manifests/deployment.yml
+++ b/manifests/deployment.yml
@@ -45,6 +45,8 @@ spec:
               secretKeyRef:
                 name: slack-gpt
                 key: openai-secret
+          - name: GPT_MODEL
+            value: gpt-4o
           - name: LANG
             value: C.UTF-8
           - name: BOT_USER_ID

--- a/src/mention.ts
+++ b/src/mention.ts
@@ -18,7 +18,7 @@ export const appMention: any = async ({ event, client, say }) => {
     }
 
     const nonNullable = <T>(value: T): value is NonNullable<T> => value != null
-    let model = 'gpt-4o'
+    let model = process.env.GPT_MODEL || 'gpt-4-turbo'
     let max_tokens = null
     const threadMessages = await Promise.all(
       replies.messages.map(async (message) => {
@@ -38,6 +38,7 @@ export const appMention: any = async ({ event, client, say }) => {
               }
 
               if (encodedImage) {
+                model = 'gpt-4-vision-preview'
                 max_tokens = 4096
                 contents.push(
                   {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,7 +10,7 @@ if (!apiKey) {
 }
 const openai = new OpenAI({ apiKey })
 
-const GPT_MODEL = 'gpt-4-1106-preview'
+const GPT_MODEL = process.env.GPT_MODEL || 'gpt-4-turbo'
 
 const GPT_MAX_TOKEN = 128000
 


### PR DESCRIPTION
GPT の model を環境変数で指定できるようにしました
指定されていない場合は `gpt-4-turbo` が入るようになってます

画像に対応していないモデルが指定される可能性を考慮して、画像が添付されている場合は自動的に `gpt-4-vision-preview` を使うように戻しました

I have made it possible to specify the GPT model using environment variables. If no model is specified, `gpt-4-turbo` will be used by default.

Considering the possibility that a model not compatible with images might be specified, I have reverted to automatically using `gpt-4-vision-preview` when an image is attached.
