### PR TITLE
ハードコードされたモデル名を環境変数から取得できるよう変更

### DIFF
--- a/src/mention.ts
+++ b/src/mention.ts
@@ -50,7 +50,7 @@ export const appMention: any = async ({ event, client, say }) => {
                 }
 
                 if (encodedImage) {
-                  model = 'gpt-4o'
+                  model = process.env.IMAGE_MODEL || 'gpt-4o'
                   max_tokens = 4096
                   contents.push({
                     image_url: {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,11 +12,11 @@ const openai = new OpenAI({ apiKey })
 
 const GPT_MODEL = process.env.GPT_MODEL || 'gpt-4-turbo'
 
-const GPT_MAX_TOKEN = 128000
+const GPT_MAX_TOKEN = Number(process.env.GPT_MAX_TOKEN || '128000')
 
 async function getNumberOfTokens (messages: ChatCompletionUserMessageParam[]): Promise<number> {
   let length = 0
-  const model = 'gpt-4' as TiktokenModel
+  const model = (process.env.TIKTOKEN_MODEL || 'gpt-4') as TiktokenModel
 
   const encoding = encoding_for_model(model)
   for (const message of messages) {


### PR DESCRIPTION
まだ先のことだとは思いますが、gpt-4系が使えなくなったら動かなくなると思うので依存している部分を変更できるようにします。